### PR TITLE
enforce encoding on reads / writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ var LevelUp = require("level");
 var Sublevel = require("level-sublevel");
 var db = Sublevel(LevelUp("./db"));
 
-//you have to specify key- and valueEncoding
 var users = db.sublevel("users", { keyEncoding: 'binary', valueEncoding: "json" })
 var levelUserDb = require("level-userdb")(users);
 


### PR DESCRIPTION
we can't be sure how the underlying level instance is configured. enforce
key and value encoding on reads and writes to make sure data
isn't lost being converted to strings
