### PR TITLE
null errors

### DIFF
--- a/db.js
+++ b/db.js
@@ -141,7 +141,7 @@ module.exports = function(db) {
           .put(k(newEmail), user, {valueEncoding: "json"})
           .write(function(err) {
             done()
-            cb.call(null, arguments)
+            cb(err)
           })
       })
     })
@@ -164,7 +164,7 @@ module.exports = function(db) {
           userObj.data = user.data;
           self.put(k(email), userObj, function(err) {
             done()
-            cb.call(null, arguments)
+            cb(err)
           })
         })
       }, insecure)
@@ -187,7 +187,7 @@ module.exports = function(db) {
         user.modifiedTimestamp = genTimestamp()
         self.put(k(email), user, function(err) {
           done()
-          cb.call(null, arguments)
+          cb(err)
         })
       })
     })

--- a/test/test_db.js
+++ b/test/test_db.js
@@ -262,7 +262,7 @@ describe('db', function() {
         ], function(err, res) {
           var found = 0
           res.forEach(function(item) {
-            if (item.name === "NotFoundError") found++
+            if (item && item.name === "NotFoundError") found++
           })
           expect(found).to.eql(1)
           done()


### PR DESCRIPTION
Ensured that `err` is `null` or a levelup error (was getting `{}`)
